### PR TITLE
总是返回最近一千条记录、cloudApi 也记录响应代码等

### DIFF
--- a/collector.js
+++ b/collector.js
@@ -37,13 +37,13 @@ module.exports = function(instanceName) {
       utils.mergeUrlToUrls(realtimeBucket.routers, url);
     },
 
-    logCloudApi: function(requestUrl, responseType, responseTime) {
+    logCloudApi: function(requestUrl, statusCode, responseTime) {
       var url = {
         url: requestUrl,
         totalResponseTime: responseTime
       };
 
-      url[responseType] = 1;
+      url[statusCode] = 1;
 
       utils.mergeUrlToUrls(instanceBucket.cloudApi, url);
       utils.mergeUrlToUrls(realtimeBucket.cloudApi, url);

--- a/index.js
+++ b/index.js
@@ -141,15 +141,6 @@ function injectCloudRequest(AV, collector, options) {
 
     var cloudUrl = generateUrl(route, className, objectId, method);
 
-    var responseType = function(err) {
-      if (!err)
-        return 'success';
-      else if (err.code > 0)
-        return 'clientError';
-      else
-        return 'serverError';
-    };
-
     var responseTime = function() {
       return Date.now() - startedAt.getTime();
     };
@@ -159,10 +150,10 @@ function injectCloudRequest(AV, collector, options) {
         return;
 
       debug('cloudApi: %s %s', cloudUrl, statusCode);
-      collector.logCloudApi(cloudUrl, responseType(), responseTime());
+      collector.logCloudApi(cloudUrl, statusCode, responseTime());
     }, function(err) {
       debug('cloudApi: %s Error %s', cloudUrl, err.code);
-      collector.logCloudApi(cloudUrl, responseType(err), responseTime());
+      collector.logCloudApi(cloudUrl, err.code, responseTime());
     });
 
     return promise;

--- a/index.js
+++ b/index.js
@@ -53,6 +53,11 @@ module.exports = exports = function(options) {
       match: /^GET .*\.(css|js|jpe?g|gif|png|woff2?|ico)$/,
       rewrite: 'GET *.$1'
     });
+
+    rewriteRules.push({
+      match: /^(.*)[a-f0-9]{24}(.*)$/,
+      rewrite: '$1:objectId$2'
+    });
   }
 
   var collector = options.collector || createCollector(process.pid + '@' + os.hostname());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leanengine-sniper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "LeanEngine monitor middleware for express app",
   "repository": {
     "type": "git",

--- a/public/index.js
+++ b/public/index.js
@@ -55,7 +55,7 @@ function useCloudData() {
   }, function(data) {
     resetInitalData();
 
-    var flattenedLogs = flattenLogs(data, initialData);
+    var flattenedLogs = flattenLogs(data.reverse(), initialData);
 
     initialData.routers = flattenedLogs.routers;
     initialData.cloudApi = flattenedLogs.cloudApi;

--- a/public/utils.js
+++ b/public/utils.js
@@ -39,7 +39,7 @@
     if (targetUrl) {
       utils.mergeUrl(targetUrl, url);
     } else {
-      urls.push(url);
+      urls.push(_.clone(url));
     }
   };
 

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ module.exports = function(AV, options) {
     if (!isNaN(to.valueOf()))
       query.lessThan('createdAt', to);
 
-    query.limit(1000).find().then(function(data) {
+    query.descending('createdAt').limit(1000).find().then(function(data) {
       res.json(data);
     });
   });

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var express = require('express');
+var request = require('supertest');
+var async = require('async');
+var AV = require('leanengine');
+var _ = require('underscore');
+
+var sniper = require('../index');
+
+AV.initialize('hOm6fe8KE285nUXsB6AR267i', 'c7Y2X8NINFhCTGWsFSNLTUns', '5mSJOWdhxSqVyg4CQsu0tJNa');
+
+var app = express();
+
+app.use(sniper({
+  AV: AV
+}));
+
+app.use(asyncMiddleware);
+
+app.get('/topic/:id', emptyResponse);
+app.post('/topic/create', asyncMiddleware, emptyResponse);
+
+app.use(emptyResponse);
+
+describe('benchmark', function () {
+  this.timeout(30000);
+
+  it('1000 requests', function(done) {
+    async.timesLimit(1000, 100, function(times, next) {
+      async.parallel([
+        function(callback) {
+          request(app).get('/topic/563e27fe60b259ca8e1cfb91').end(callback);
+        },
+        function(callback) {
+          request(app).post('/topic/create').end(callback);
+        }
+      ], next);
+    }, done);
+  });
+
+  it('1000 requests on 50 unique url', function(done) {
+    async.timesLimit(1000, 20, function(times, next) {
+      request(app).get('/pages/' + _.random(0, 50)).end(next);
+    }, done);
+  });
+});
+
+function emptyResponse(req, res) {
+  res.send();
+}
+
+function asyncMiddleware(req, res, next) {
+  setTimeout(next, 1);
+}

--- a/test/collector.js
+++ b/test/collector.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var chai = require('chai');
+var _ = require('underscore');
+
+var createCollector = require('../collector');
+
+chai.Should();
+
+describe('collector', function () {
+  var collector = createCollector('collectorTest');
+
+  it('logRouter', function() {
+    collector.logRouter('POST /topic/create', 200, 100);
+    collector.logRouter('POST /topic/create', 200, 150);
+    collector.logRouter('POST /topic/create', 400, 10);
+    collector.logRouter('GET /topic/:id', 404, 10);
+  });
+
+  it('logCloudApi', function() {
+    collector.logCloudApi('GET classes/Topic/:id', 'success', 15);
+    collector.logCloudApi('GET classes/Topic/:id', 'success', 20);
+    collector.logCloudApi('GET classes/Topic/:id', 'clientError', 10);
+  })
+
+  it('flush', function() {
+    var bucket = collector.flush();
+    var realtimeBucket = collector.flushRealtime();
+
+    realtimeBucket.should.not.equal(bucket);
+    realtimeBucket.routers[0].should.not.equal(_.findWhere(bucket.routers, {url: realtimeBucket.routers[0].url}))
+
+    _.sortBy(bucket.routers, 'url').should.be.eql(_.sortBy([
+      {url: 'POST /topic/create', '200': 2, '400': 1, totalResponseTime: 260},
+      {url: 'GET /topic/:id', '404': 1, totalResponseTime: 10},
+    ], 'url'));
+
+    _.sortBy(bucket.cloudApi, 'url').should.be.eql(_.sortBy([
+      {url: 'GET classes/Topic/:id', 'success': 2, 'clientError': 1, totalResponseTime: 45}
+    ], 'url'));
+
+    collector.flush().should.be.eql({
+      instance: 'collectorTest',
+      routers: [],
+      cloudApi: []
+    });
+  });
+});

--- a/test/request-url.js
+++ b/test/request-url.js
@@ -80,6 +80,8 @@ describe('request-url', function () {
 
   testUrlPattern('GET', '/2.0/topic/reply/1', 'GET /2.0/topic/reply/:replyId');
   testUrlPattern('GET', '/2.0/topic/reply/2', 'GET /2.0/topic/reply/:replyId');
+
+  testUrlPattern('GET', '/2.0/posts/563e27fe60b259ca8e1cfb91', 'GET /2.0/posts/:objectId');
 });
 
 function testUrlPattern(method, url, urlPattern) {


### PR DESCRIPTION
* [x] 默认自动将 URL 中类似 ObjectID（`/[a-f0-9]{24}/`）替换成占位符
* [x] 修复一个会导致计数不准（偏大）的问题， 因为 mergeUrlToUrls 中忘记了 clone 数据
* ~~在内存中改用 Object 而不是 Array 来存储 url 信息~~ 后来发现并不能提高性能
* [x] 将 cloudApi 改为和 routers 一样的格式，也记录响应代码
* [x] 服务器总是返回最近一千条记录
* [x] 添加自动测试：

  * collector
  * 处理请求的性能测试